### PR TITLE
fix: aptos move compile for 0.3.1

### DIFF
--- a/sources/lending.move
+++ b/sources/lending.move
@@ -404,42 +404,52 @@ module hippo_tutorial::lend2 {
         usdc_coin: Coin<FakeUSDC>,
         usdt_coin: Coin<FakeUSDT>,
 
-        btc_cap: coin::MintCapability<FakeBTC>,
-        eth_cap: coin::MintCapability<FakeETH>,
-        usdc_cap: coin::MintCapability<FakeUSDC>,
-        usdt_cap: coin::MintCapability<FakeUSDT>,
-
         btc_burn: coin::BurnCapability<FakeBTC>,
         eth_burn: coin::BurnCapability<FakeETH>,
         usdc_burn: coin::BurnCapability<FakeUSDC>,
         usdt_burn: coin::BurnCapability<FakeUSDT>,
+
+        btc_freeze: coin::FreezeCapability<FakeBTC>,
+        eth_freeze: coin::FreezeCapability<FakeETH>,
+        usdc_freeze: coin::FreezeCapability<FakeUSDC>,
+        usdt_freeze: coin::FreezeCapability<FakeUSDT>,
+
+        btc_mint: coin::MintCapability<FakeBTC>,
+        eth_mint: coin::MintCapability<FakeETH>,
+        usdc_mint: coin::MintCapability<FakeUSDC>,
+        usdt_mint: coin::MintCapability<FakeUSDT>,
     }
 
     #[cmd]
     public entry fun init_fake_pools(admin: &signer) acquires LendingProtocol {
         use std::string;
         let name = string::utf8(b"name");
-        let (btc_cap, btc_burn) = coin::initialize<FakeBTC>(admin, copy name, copy name, 0, false);
-        let (eth_cap, eth_burn) = coin::initialize<FakeETH>(admin, copy name, copy name, 0, false);
-        let (usdc_cap, usdc_burn) = coin::initialize<FakeUSDC>(admin, copy name, copy name, 0, false);
-        let (usdt_cap, usdt_burn) = coin::initialize<FakeUSDT>(admin, copy name, copy name, 0, false);
+        let (btc_burn, btc_freeze, btc_mint) = coin::initialize<FakeBTC>(admin, copy name, copy name, 0, false);
+        let (eth_burn, eth_freeze, eth_mint) = coin::initialize<FakeETH>(admin, copy name, copy name, 0, false);
+        let (usdc_burn, usdc_freeze, usdc_mint) = coin::initialize<FakeUSDC>(admin, copy name, copy name, 0, false);
+        let (usdt_burn, usdt_freeze, usdt_mint) = coin::initialize<FakeUSDT>(admin, copy name, copy name, 0, false);
 
         let mint_amount = 1000000000000;
         move_to(admin, FreeCoins {
-            btc_coin: coin::mint(mint_amount, &btc_cap),
-            eth_coin: coin::mint(mint_amount, &eth_cap),
-            usdc_coin: coin::mint(mint_amount, &usdc_cap),
-            usdt_coin: coin::mint(mint_amount, &usdt_cap),
-
-            btc_cap,
-            eth_cap,
-            usdc_cap,
-            usdt_cap,
+            btc_coin: coin::mint(mint_amount, &btc_mint),
+            eth_coin: coin::mint(mint_amount, &eth_mint),
+            usdc_coin: coin::mint(mint_amount, &usdc_mint),
+            usdt_coin: coin::mint(mint_amount, &usdt_mint),
 
             btc_burn,
             eth_burn,
             usdc_burn,
             usdt_burn,
+
+            btc_freeze,
+            eth_freeze,
+            usdc_freeze,
+            usdt_freeze,
+
+            btc_mint,
+            eth_mint,
+            usdc_mint,
+            usdt_mint,
         });
 
         admin_init(admin);


### PR DESCRIPTION
`aptos move compile` was failing due to improper destructuring of values from `coin::initialize` from [here](https://github.com/aptos-labs/aptos-core/blob/c238d8d1156b842ec768e3ad646643f1b4165f5b/aptos-move/framework/aptos-framework/sources/coin.move#L314) shown  below
```
    public fun initialize<CoinType>(
        account: &signer,
        name: string::String,
        symbol: string::String,
        decimals: u8,
        monitor_supply: bool,
    ): (BurnCapability<CoinType>, FreezeCapability<CoinType>, MintCapability<CoinType>) {
        initialize_internal(account, name, symbol, decimals, monitor_supply, false)
    }
```

``` 
$ aptos move compile
error[E04007]: incompatible types
    ┌─ /home/aadhi/Desktop/tutorial-lending/sources/lending.move:422:13
    │
422 │         let (btc_cap, btc_burn) = coin::initialize<FakeBTC>(admin, copy name, copy name, 0, false);
    │             ^^^^^^^^^^^^^^^^^^^
    │             │
    │             Invalid value for binding
    │             Expected expression list of length 2: '(_, _)'
    │
    ┌─ /home/aadhi/.move/https___github_com_aptos-labs_aptos-core_git_3910637893b6aed4af73b19a2c429ef717e1ee26/aptos-move/framework/aptos-framework/sources/coin.move:313:8
    │
313 │     ): (BurnCapability<CoinType>, FreezeCapability<CoinType>, MintCapability<CoinType>) {
    │        -------------------------------------------------------------------------------- Given expression list of length 3: '((aptos_framework=0x1)::coin::BurnCapability<(hippo_tutorial=0xA61E1E86E9F596E483283727D2739BA24B919012720648C29380F9CD0A96C11A)::lend2::FakeBTC>, (aptos_framework=0x1)::coin::FreezeCapability<(hippo_tutorial=0xA61E1E86E9F596E483283727D2739BA24B919012720648C29380F9CD0A96C11A)::lend2::FakeBTC>, (aptos_framework=0x1)::coin::MintCapability<(hippo_tutorial=0xA61E1E86E9F596E483283727D2739BA24B919012720648C29380F9CD0A96C11A)::lend2::FakeBTC>)'
```